### PR TITLE
Fixed the corrupted behavior of defaults values

### DIFF
--- a/lib/active_data/model/attributable.rb
+++ b/lib/active_data/model/attributable.rb
@@ -51,8 +51,8 @@ module ActiveData
 
       def read_attribute name
         attribute = self.class._attributes[name]
-        source = @attributes[name].nil? ? attribute.default_value(self) : @attributes[name]
-        attribute.type_cast source
+        @attributes[name] = attribute.default_value(self) if @attributes[name].nil?
+        attribute.type_cast @attributes[name]
       end
       alias_method :[], :read_attribute
 

--- a/spec/lib/active_data/model/attributable_spec.rb
+++ b/spec/lib/active_data/model/attributable_spec.rb
@@ -34,4 +34,21 @@ describe ActiveData::Model::Attributable do
     specify { expect { subject.calc = 15 } .to change { subject.calc } .from(5).to(15) }
   end
 
+  context 'calculating default values' do
+    let(:klass) do
+      Class.new do
+        include ActiveData::Model::Attributable
+
+        attribute(:rand, type: Integer) { rand 1000000 }
+
+        def initialize
+          @attributes = self.class.initialize_attributes
+        end
+      end
+    end
+
+    subject { klass.new }
+    specify { subject.rand.should == subject.rand }
+  end
+
 end


### PR DESCRIPTION
Default values was calculated each time as we called read_attribute

``` ruby
class MyClass
  include ActiveData::Model

  attribute :id, type: String, default: proc{SecureRandom.uuid}
end
my_class = MyClass.new
pp my_class.id
pp my_class.id
```

```
"f50d373d-16b8-436a-a36c-d8c6903994d8"
"1fca043d-39f1-4e9f-9f01-87295e24ae48"
```

This is the patch to fix issue #1  
