### PR TITLE
Add :references_many association

### DIFF
--- a/lib/active_data/model/associations.rb
+++ b/lib/active_data/model/associations.rb
@@ -2,9 +2,11 @@ require 'active_data/model/associations/reflections/embeds_many'
 require 'active_data/model/associations/reflections/embeds_one'
 require 'active_data/model/associations/reflections/embeds_many'
 require 'active_data/model/associations/reflections/references_one'
+require 'active_data/model/associations/reflections/references_many'
 require 'active_data/model/associations/embeds_one'
 require 'active_data/model/associations/embeds_many'
 require 'active_data/model/associations/references_one'
+require 'active_data/model/associations/references_many'
 require 'active_data/model/associations/nested_attributes'
 
 module ActiveData
@@ -21,7 +23,8 @@ module ActiveData
         {
           embeds_many: Reflections::EmbedsMany,
           embeds_one: Reflections::EmbedsOne,
-          references_one: Reflections::ReferencesOne
+          references_one: Reflections::ReferencesOne,
+          references_many: Reflections::ReferencesMany
         }.each do |(name, reflection_class)|
           define_singleton_method name do |*args, &block|
             reflection = reflection_class.new self, *args, &block

--- a/lib/active_data/model/associations/collection_proxy.rb
+++ b/lib/active_data/model/associations/collection_proxy.rb
@@ -4,10 +4,8 @@ module ActiveData
       class CollectionProxy
         include Enumerable
 
-        delegate :target, :build, :create, :create!, :save, :save!,
-          :loaded?, :reload, :clear, :concat, to: :@association
+        delegate :target, :save, :save!, :loaded?, :reload, :clear, :concat, to: :@association
         delegate :each, :size, :length, :first, :last, :empty?, :many?, :==, :dup, to: :target
-        alias_method :new, :build
         alias_method :<<, :concat
         alias_method :push, :concat
 

--- a/lib/active_data/model/associations/embedded_collection_proxy.rb
+++ b/lib/active_data/model/associations/embedded_collection_proxy.rb
@@ -5,6 +5,7 @@ module ActiveData
     module Associations
       class EmbeddedCollectionProxy < CollectionProxy
         delegate :build, :create, :create!, to: :@association
+        alias_method :new, :build
       end
     end
   end

--- a/lib/active_data/model/associations/embedded_collection_proxy.rb
+++ b/lib/active_data/model/associations/embedded_collection_proxy.rb
@@ -1,0 +1,11 @@
+require 'active_data/model/associations/collection_proxy'
+
+module ActiveData
+  module Model
+    module Associations
+      class EmbeddedCollectionProxy < CollectionProxy
+        delegate :build, :create, :create!, to: :@association
+      end
+    end
+  end
+end

--- a/lib/active_data/model/associations/embeds_many.rb
+++ b/lib/active_data/model/associations/embeds_many.rb
@@ -1,5 +1,5 @@
 require 'active_data/model/associations/base'
-require 'active_data/model/associations/collection_proxy'
+require 'active_data/model/associations/embedded_collection_proxy'
 
 module ActiveData
   module Model
@@ -49,7 +49,7 @@ module ActiveData
 
         def reader force_reload = false
           reload if force_reload
-          @proxy ||= CollectionProxy.new self
+          @proxy ||= EmbeddedCollectionProxy.new self
         end
 
         def writer objects

--- a/lib/active_data/model/associations/referenced_collection_proxy.rb
+++ b/lib/active_data/model/associations/referenced_collection_proxy.rb
@@ -4,7 +4,7 @@ module ActiveData
   module Model
     module Associations
       class ReferencedCollectionProxy < CollectionProxy
-        METHODS_EXCLUDED_FROM_DELEGATION = %i[build create create!]
+        METHODS_EXCLUDED_FROM_DELEGATION = %w[build create create!].map(&:to_sym).freeze
         delegate :scope, to: :@association
 
         def method_missing(method, *args, &block)
@@ -15,7 +15,7 @@ module ActiveData
           delegate_to_scope?(method) || super
         end
 
-        private
+      private
 
         def delegate_to_scope?(method)
           METHODS_EXCLUDED_FROM_DELEGATION.exclude?(method) && scope.respond_to?(method)

--- a/lib/active_data/model/associations/referenced_collection_proxy.rb
+++ b/lib/active_data/model/associations/referenced_collection_proxy.rb
@@ -1,0 +1,26 @@
+require 'active_data/model/associations/collection_proxy'
+
+module ActiveData
+  module Model
+    module Associations
+      class ReferencedCollectionProxy < CollectionProxy
+        METHODS_EXCLUDED_FROM_DELEGATION = %i[build create create!]
+        delegate :scope, to: :@association
+
+        def method_missing(method, *args, &block)
+          delegate_to_scope?(method) ? scope.send(method, *args, &block) : super
+        end
+
+        def respond_to_missing?(method, include_private = false)
+          delegate_to_scope?(method) || super
+        end
+
+        private
+
+        def delegate_to_scope?(method)
+          METHODS_EXCLUDED_FROM_DELEGATION.exclude?(method) && scope.respond_to?(method)
+        end
+      end
+    end
+  end
+end

--- a/lib/active_data/model/associations/references_many.rb
+++ b/lib/active_data/model/associations/references_many.rb
@@ -1,0 +1,74 @@
+require 'active_data/model/associations/base'
+
+module ActiveData
+  module Model
+    module Associations
+      class ReferencesMany < Base
+
+        def save
+          present_keys = target.reject { |t| t.marked_for_destruction? }.map(&reflection.association_primary_key)
+          write_source(present_keys)
+          true
+        end
+        alias_method :save!, :save
+
+        def target= object
+          loaded!
+          @target = object.to_a
+        end
+
+        def target
+          return @target if loaded?
+          self.target = read_source.present? ? scope.to_a : []
+        end
+
+        def reader force_reload = false
+          reload if force_reload || source_changed?
+          @proxy ||= CollectionProxy.new self
+        end
+
+        def replace objects
+          transaction do
+            clear
+            append objects
+          end
+        end
+        alias_method :writer, :replace
+
+        def concat(*objects)
+          append objects.flatten
+        end
+
+        def clear
+          write_source([])
+          reload.empty?
+        end
+
+        def scope
+          reflection.klass.where(reflection.association_primary_key => read_source)
+        end
+
+        private
+
+        def append objects
+          puts "append #{objects.inspect}"
+          objects.each do |object|
+            raise AssociationTypeMismatch.new(reflection.klass, object.class) unless object.is_a?(reflection.klass)
+            raise AssociationObjectNotPersisted unless object.persisted?
+            target[target.size] = object
+            save
+          end
+          target
+        end
+
+        def identifiers
+          target.map(&reflection.association_primary_key)
+        end
+
+        def source_changed?
+          read_source != identifiers
+        end
+      end
+    end
+  end
+end

--- a/lib/active_data/model/associations/references_many.rb
+++ b/lib/active_data/model/associations/references_many.rb
@@ -1,4 +1,5 @@
 require 'active_data/model/associations/base'
+require 'active_data/model/associations/collection_proxy'
 
 module ActiveData
   module Model
@@ -6,7 +7,7 @@ module ActiveData
       class ReferencesMany < Base
 
         def save
-          present_keys = target.reject { |t| t.marked_for_destruction? }.map(&reflection.association_primary_key)
+          present_keys = target.reject { |t| t.marked_for_destruction? }.map(&reflection.association_primary_key).uniq
           write_source(present_keys)
           true
         end
@@ -37,6 +38,7 @@ module ActiveData
 
         def concat(*objects)
           append objects.flatten
+          reader
         end
 
         def clear
@@ -51,7 +53,6 @@ module ActiveData
         private
 
         def append objects
-          puts "append #{objects.inspect}"
           objects.each do |object|
             raise AssociationTypeMismatch.new(reflection.klass, object.class) unless object.is_a?(reflection.klass)
             raise AssociationObjectNotPersisted unless object.persisted?

--- a/lib/active_data/model/associations/references_many.rb
+++ b/lib/active_data/model/associations/references_many.rb
@@ -54,7 +54,7 @@ module ActiveData
           reflection.klass.where(reflection.primary_key => read_source)
         end
 
-        private
+      private
 
         def append objects
           objects.each do |object|

--- a/lib/active_data/model/associations/references_many.rb
+++ b/lib/active_data/model/associations/references_many.rb
@@ -1,5 +1,5 @@
 require 'active_data/model/associations/base'
-require 'active_data/model/associations/collection_proxy'
+require 'active_data/model/associations/referenced_collection_proxy'
 
 module ActiveData
   module Model
@@ -29,7 +29,7 @@ module ActiveData
 
         def reader force_reload = false
           reload if force_reload || source_changed?
-          @proxy ||= CollectionProxy.new self
+          @proxy ||= ReferencedCollectionProxy.new self
         end
 
         def replace objects

--- a/lib/active_data/model/associations/references_one.rb
+++ b/lib/active_data/model/associations/references_one.rb
@@ -5,6 +5,7 @@ module ActiveData
     module Associations
       class ReferencesOne < Base
         def save
+          return false if target && !target.persisted?
           if target.present? && !target.marked_for_destruction?
             write_source identifier
           else
@@ -12,7 +13,10 @@ module ActiveData
           end
           true
         end
-        alias_method :save!, :save
+
+        def save!
+          save or raise AssociationObjectNotPersisted
+        end
 
         def target= object
           loaded!
@@ -32,22 +36,25 @@ module ActiveData
         def replace object
           unless object.nil?
             raise AssociationTypeMismatch.new(reflection.klass, object.class) unless object.is_a?(reflection.klass)
-            raise AssociationObjectNotPersisted unless object.persisted?
           end
-          self.target = object
-          save!
+
+          transaction do
+            self.target = object
+            save!
+          end
+
           target
         end
         alias_method :writer, :replace
 
         def scope
-          reflection.klass.where(reflection.association_primary_key => read_source)
+          reflection.klass.where(reflection.primary_key => read_source)
         end
 
         private
 
         def identifier
-          target.try(reflection.association_primary_key)
+          target.try(reflection.primary_key)
         end
 
         def source_changed?

--- a/lib/active_data/model/associations/references_one.rb
+++ b/lib/active_data/model/associations/references_one.rb
@@ -51,7 +51,7 @@ module ActiveData
           reflection.klass.where(reflection.primary_key => read_source)
         end
 
-        private
+      private
 
         def identifier
           target.try(reflection.primary_key)

--- a/lib/active_data/model/associations/reflections/reference_reflection.rb
+++ b/lib/active_data/model/associations/reflections/reference_reflection.rb
@@ -1,0 +1,41 @@
+require 'active_data/model/associations/reflections/base'
+
+module ActiveData
+  module Model
+    module Associations
+      module Reflections
+        class ReferenceReflection < Base
+          def read_source object
+            object.read_attribute(reference_key)
+          end
+
+          def write_source object, value
+            object.write_attribute(reference_key, value)
+          end
+
+          def reference_key
+            raise NotImplementedError
+          end
+
+          def primary_key
+            :id
+          end
+
+          private
+
+          def define_methods!
+            owner.class_eval <<-EOS
+              def #{name} force_reload = false
+                association(:#{name}).reader(force_reload)
+              end
+
+              def #{name}= value
+                association(:#{name}).writer(value)
+              end
+            EOS
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_data/model/associations/reflections/reference_reflection.rb
+++ b/lib/active_data/model/associations/reflections/reference_reflection.rb
@@ -21,7 +21,7 @@ module ActiveData
             :id
           end
 
-          private
+        private
 
           def define_methods!
             owner.class_eval <<-EOS

--- a/lib/active_data/model/associations/reflections/references_many.rb
+++ b/lib/active_data/model/associations/reflections/references_many.rb
@@ -1,0 +1,58 @@
+require 'active_data/model/associations/reflections/base'
+
+module ActiveData
+  module Model
+    module Associations
+      module Reflections
+        class ReferencesMany < Base
+          def macro
+            :references_many
+          end
+
+          def collection?
+            true
+          end
+
+          def association_class
+            ActiveData::Model::Associations::ReferencesMany
+          end
+
+          def read_source object
+            value = object.read_attribute(reference_key)
+            value
+          end
+
+          def write_source object, value
+            object.write_attribute(reference_key, value)
+          end
+
+          def reference_key
+            :"#{name.to_s.singularize}_ids"
+          end
+
+          def association_primary_key
+            :id
+          end
+
+          def attributes
+            {reference_key => {type: Integer, mode: :collection}}
+          end
+
+          private
+
+          def define_methods!
+            owner.class_eval <<-EOS
+              def #{name} force_reload = false
+                association(:#{name}).reader(force_reload)
+              end
+
+              def #{name}= value
+                association(:#{name}).writer(value)
+              end
+            EOS
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_data/model/associations/reflections/references_many.rb
+++ b/lib/active_data/model/associations/reflections/references_many.rb
@@ -1,14 +1,10 @@
-require 'active_data/model/associations/reflections/base'
+require 'active_data/model/associations/reflections/reference_reflection'
 
 module ActiveData
   module Model
     module Associations
       module Reflections
-        class ReferencesMany < Base
-          def macro
-            :references_many
-          end
-
+        class ReferencesMany < ReferenceReflection
           def collection?
             true
           end
@@ -17,39 +13,12 @@ module ActiveData
             ActiveData::Model::Associations::ReferencesMany
           end
 
-          def read_source object
-            value = object.read_attribute(reference_key)
-            value
-          end
-
-          def write_source object, value
-            object.write_attribute(reference_key, value)
-          end
-
           def reference_key
             :"#{name.to_s.singularize}_ids"
           end
 
-          def association_primary_key
-            :id
-          end
-
           def attributes
             {reference_key => {type: Integer, mode: :collection}}
-          end
-
-          private
-
-          def define_methods!
-            owner.class_eval <<-EOS
-              def #{name} force_reload = false
-                association(:#{name}).reader(force_reload)
-              end
-
-              def #{name}= value
-                association(:#{name}).writer(value)
-              end
-            EOS
           end
         end
       end

--- a/lib/active_data/model/associations/reflections/references_one.rb
+++ b/lib/active_data/model/associations/reflections/references_one.rb
@@ -1,10 +1,10 @@
-require 'active_data/model/associations/reflections/base'
+require 'active_data/model/associations/reflections/reference_reflection'
 
 module ActiveData
   module Model
     module Associations
       module Reflections
-        class ReferencesOne < Base
+        class ReferencesOne < ReferenceReflection
           def collection?
             false
           end
@@ -13,38 +13,12 @@ module ActiveData
             ActiveData::Model::Associations::ReferencesOne
           end
 
-          def read_source object
-            object.read_attribute(reference_key)
-          end
-
-          def write_source object, value
-            object.write_attribute(reference_key, value)
-          end
-
           def reference_key
             :"#{name}_id"
           end
 
-          def association_primary_key
-            :id
-          end
-
           def attributes
             {reference_key => {type: Integer}}
-          end
-
-          private
-
-          def define_methods!
-            owner.class_eval <<-EOS
-              def #{name} force_reload = false
-                association(:#{name}).reader(force_reload)
-              end
-
-              def #{name}= value
-                association(:#{name}).writer(value)
-              end
-            EOS
           end
         end
       end

--- a/spec/lib/active_data/active_record/associations_spec.rb
+++ b/spec/lib/active_data/active_record/associations_spec.rb
@@ -137,7 +137,7 @@ describe ActiveData::ActiveRecord::Associations do
 
     specify { expect(User.reflect_on_association(:projects).klass).to eq(User::Project) }
     specify { expect(User.new.projects).to eq([]) }
-    specify { expect(User.new.tap { |u| u.projects.create(title: 'Project') }.projects).to be_a(ActiveData::Model::Associations::CollectionProxy) }
+    specify { expect(User.new.tap { |u| u.projects.create(title: 'Project') }.projects).to be_a(ActiveData::Model::Associations::EmbeddedCollectionProxy) }
     specify { expect(User.new.tap { |u| u.projects.create(title: 'Project') }.read_attribute(:projects)).to eq([{title: 'Project'}].to_json) }
 
     specify { expect(User.reflect_on_association(:profile).klass).to eq(User::Profile) }

--- a/spec/lib/active_data/model/associations/references_many_spec.rb
+++ b/spec/lib/active_data/model/associations/references_many_spec.rb
@@ -1,0 +1,162 @@
+# encoding: UTF-8
+require 'spec_helper'
+
+describe ActiveData::Model::Associations::ReferencesMany do
+  before do
+    stub_model(:dummy)
+    stub_class(:author, ActiveRecord::Base)
+
+    stub_model(:book) do
+      include ActiveData::Model::Persistence
+      include ActiveData::Model::Associations
+
+      attribute :title
+      references_many :authors
+    end
+  end
+
+  let(:author) { Author.create!(name: 'Rick') }
+  let(:other) { Author.create!(name: 'Ben') }
+
+  let(:book) { Book.new }
+  let(:association) { book.association(:authors) }
+
+  let(:existing_book) { Book.instantiate title: 'Genesis', author_ids: [author.id] }
+  let(:existing_association) { existing_book.association(:authors) }
+
+  describe 'book#association' do
+    specify { expect(association).to be_a described_class }
+    specify { expect(association).to eq(book.association(:authors)) }
+  end
+
+  describe '#target' do
+    specify { expect(association.target).to eq([]) }
+    specify { expect(existing_association.target).to eq(existing_book.authors) }
+    specify { expect { association.concat author }.to change { association.target.count }.to(1) }
+  end
+
+  describe '#loaded?' do
+    specify { expect(association.loaded?).to eq(false) }
+    specify { expect { association.target }.to change { association.loaded? }.to(true) }
+    specify { expect { association.replace([]) }.to change { association.loaded? }.to(true) }
+    specify { expect { existing_association.replace([]) }.to change { existing_association.loaded? }.to(true) }
+  end
+
+  describe '#reload' do
+    specify { expect(association.reload).to eq([]) }
+
+    specify { expect(existing_association.reload).to eq(existing_book.authors) }
+
+    context do
+      before { existing_association.reader.last.name = 'Conan' }
+      specify { expect { existing_association.reload }
+        .to change { existing_association.reader.map(&:name) }
+        .from(['Conan']).to(['Rick']) }
+    end
+  end
+
+  describe '#reader' do
+    specify { expect(association.reader).to eq([]) }
+
+    specify { expect(existing_association.reader.first).to be_a Author }
+    specify { expect(existing_association.reader.first).to be_persisted }
+
+    context do
+      before { association.concat author }
+      specify { expect(association.reader.last).to be_a Author }
+      specify { expect(association.reader.size).to eq(1) }
+      specify { expect(association.reader(true)).to eq([author]) }
+    end
+
+    context do
+      before { existing_association.concat other }
+      specify { expect(existing_association.reader.size).to eq(2) }
+      specify { expect(existing_association.reader.last.name).to eq('Ben') }
+      specify { expect(existing_association.reader(true).size).to eq(2) }
+      specify { expect(existing_association.reader(true).last.name).to eq('Ben') }
+    end
+  end
+
+  describe '#writer' do
+    let(:new_author1) { Author.create!(name: 'John') }
+    let(:new_author2) { Author.create!(name: 'Adam') }
+
+    specify { expect { association.writer([Dummy.new]) }
+      .to raise_error ActiveData::AssociationTypeMismatch }
+
+    specify { expect { association.writer(nil) }.to raise_error NoMethodError }
+    specify { expect { association.writer(new_author1) }.to raise_error NoMethodError }
+    specify { expect(association.writer([])).to eq([]) }
+
+    specify { expect(association.writer([new_author1])).to eq([new_author1]) }
+    specify { expect { association.writer([new_author1]) }
+      .to change { association.reader.map(&:name) }.from([]).to(['John']) }
+    specify { expect { association.writer([new_author1]) }
+      .to change { book.read_attribute(:author_ids) }
+      .from([]).to([new_author1.id]) }
+
+    specify { expect { existing_association.writer([new_author1, Dummy.new, new_author2]) }
+      .to raise_error ActiveData::AssociationTypeMismatch }
+    specify { expect { existing_association.writer([new_author1, Dummy.new, new_author2]) rescue nil }
+      .not_to change { existing_book.read_attribute(:author_ids) } }
+    specify { expect { existing_association.writer([new_author1, Dummy.new, new_author2]) rescue nil }
+      .not_to change { existing_association.reader } }
+
+    specify { expect { existing_association.writer(nil) }.to raise_error NoMethodError }
+    specify { expect { existing_association.writer(nil) rescue nil }
+      .not_to change { existing_book.read_attribute(:author_ids) } }
+    specify { expect { existing_association.writer(nil) rescue nil }
+      .not_to change { existing_association.reader } }
+
+    specify { expect(existing_association.writer([])).to eq([]) }
+    specify { expect { existing_association.writer([]) }
+      .to change { existing_book.read_attribute(:author_ids) }.to([]) }
+    specify { expect { existing_association.writer([]) }
+      .to change { existing_association.reader }.from([author]).to([]) }
+
+    specify { expect(existing_association.writer([new_author1, new_author2])).to eq([new_author1, new_author2]) }
+    specify { expect { existing_association.writer([new_author1, new_author2]) }
+      .to change { existing_association.reader.map(&:name) }
+      .from(['Rick']).to(['John', 'Adam']) }
+    specify { expect { existing_association.writer([new_author1, new_author2]) }
+      .to change { existing_book.read_attribute(:author_ids) }
+      .from([author.id]).to([new_author1.id, new_author2.id]) }
+  end
+
+  describe '#concat' do
+    let(:new_author1) { Author.create!(name: 'John') }
+    let(:new_author2) { Author.create!(name: 'Adam') }
+
+    specify { expect { association.concat(Dummy.new) }
+      .to raise_error ActiveData::AssociationTypeMismatch }
+
+    specify { expect { association.concat(nil) }.to raise_error ActiveData::AssociationTypeMismatch }
+    specify { expect(association.concat([])).to eq([]) }
+    specify { expect(existing_association.concat([])).to eq(existing_book.authors) }
+    specify { expect(existing_association.concat).to eq(existing_book.authors) }
+
+    specify { expect(association.concat(new_author1)).to eq([new_author1]) }
+    specify { expect { association.concat(new_author1) }
+      .to change { association.reader.map(&:name) }.from([]).to(['John']) }
+    specify { expect { association.concat(new_author1) }
+      .to change { book.read_attribute(:author_ids) }.from([]).to([1]) }
+
+    specify { expect { existing_association.concat(new_author1, Dummy.new, new_author2) }
+      .to raise_error ActiveData::AssociationTypeMismatch }
+    specify { expect { existing_association.concat(new_author1, Dummy.new, new_author2) rescue nil }
+      .to change { existing_book.read_attribute(:author_ids) }
+      .from([author.id]).to([author.id, new_author1.id]) }
+    specify { expect { existing_association.concat(new_author1, Dummy.new, new_author2) rescue nil }
+      .to change { existing_association.reader.map(&:name) }
+      .from(['Rick']).to(['Rick', 'John']) }
+
+    specify { expect(existing_association.concat(new_author1, new_author2))
+      .to eq([author, new_author1, new_author2]) }
+    specify { expect { existing_association.concat([new_author1, new_author2]) }
+      .to change { existing_association.reader.map(&:name) }
+      .from(['Rick']).to(['Rick', 'John', 'Adam']) }
+    specify { expect { existing_association.concat([new_author1, new_author2]) }
+      .to change { existing_book.read_attribute(:author_ids) }
+      .from([author.id]).to([author.id, new_author1.id, new_author2.id]) }
+  end
+end

--- a/spec/lib/active_data/model/associations/references_many_spec.rb
+++ b/spec/lib/active_data/model/associations/references_many_spec.rb
@@ -83,6 +83,10 @@ describe ActiveData::Model::Associations::ReferencesMany do
 
     specify { expect { association.writer([Dummy.new]) }
       .to raise_error ActiveData::AssociationTypeMismatch }
+    specify { expect { association.writer([Author.new]) }
+      .to raise_error ActiveData::AssociationObjectNotPersisted }
+    specify { expect { existing_association.writer([Author.new]) rescue nil }
+      .not_to change { existing_association.target } }
 
     specify { expect { association.writer(nil) }.to raise_error NoMethodError }
     specify { expect { association.writer(new_author1) }.to raise_error NoMethodError }

--- a/spec/lib/active_data/model/associations/references_one_spec.rb
+++ b/spec/lib/active_data/model/associations/references_one_spec.rb
@@ -88,6 +88,8 @@ describe ActiveData::Model::Associations::ReferencesOne do
         .to raise_error ActiveData::AssociationTypeMismatch }
       specify { expect { association.writer(Author.new) }
         .to raise_error ActiveData::AssociationObjectNotPersisted }
+      specify { expect { association.writer(Author.new) rescue nil }
+        .not_to change { association.target } }
 
       specify { expect(association.writer(nil)).to be_nil }
       specify { expect(association.writer(new_author)).to eq(new_author) }

--- a/spec/lib/active_data/model/associations/reflections/embeds_many_spec.rb
+++ b/spec/lib/active_data/model/associations/reflections/embeds_many_spec.rb
@@ -119,7 +119,7 @@ describe ActiveData::Model::Associations::Reflections::EmbedsMany do
 
       specify { expect(User.reflect_on_association(:projects).klass).to eq(User::Project) }
       specify { expect(User.new.projects).to eq([]) }
-      specify { expect(User.new.tap { |u| u.projects.create(title: 'Project') }.projects).to be_a(ActiveData::Model::Associations::CollectionProxy) }
+      specify { expect(User.new.tap { |u| u.projects.create(title: 'Project') }.projects).to be_a(ActiveData::Model::Associations::EmbeddedCollectionProxy) }
       specify { expect(User.new.tap { |u| u.projects.create(title: 'Project') }.read_attribute(:projects)).to eq([{'title' => 'Project'}]) }
     end
 
@@ -137,7 +137,7 @@ describe ActiveData::Model::Associations::Reflections::EmbedsMany do
 
       specify { expect(User.reflect_on_association(:projects).klass).to eq(User::Project) }
       specify { expect(User.new.projects).to eq([]) }
-      specify { expect(User.new.tap { |u| u.projects.create(title: 'Project') }.projects).to be_a(ActiveData::Model::Associations::CollectionProxy) }
+      specify { expect(User.new.tap { |u| u.projects.create(title: 'Project') }.projects).to be_a(ActiveData::Model::Associations::EmbeddedCollectionProxy) }
       specify { expect(User.new.tap { |u| u.projects.create(title: 'Project') }.read_attribute(:projects)).to eq([{'title' => 'Project', 'value' => nil}]) }
     end
   end

--- a/spec/lib/active_data/model/associations/reflections/references_many_spec.rb
+++ b/spec/lib/active_data/model/associations/reflections/references_many_spec.rb
@@ -39,6 +39,10 @@ describe ActiveData::Model::Associations::Reflections::ReferencesMany do
   end
 
   describe '#author' do
+    it { expect(book.authors).not_to respond_to(:build) }
+    it { expect(book.authors).not_to respond_to(:create) }
+    it { expect(book.authors).not_to respond_to(:create!) }
+
     describe '#clear' do
       it { expect { book_with_author.authors.clear }.to change { book_with_author.authors }.from([author]).to([]) }
     end

--- a/spec/lib/active_data/model/associations/reflections/references_many_spec.rb
+++ b/spec/lib/active_data/model/associations/reflections/references_many_spec.rb
@@ -3,7 +3,9 @@ require 'spec_helper'
 
 describe ActiveData::Model::Associations::Reflections::ReferencesMany do
   before do
-    stub_class(:author, ActiveRecord::Base)
+    stub_class(:author, ActiveRecord::Base) do
+      scope :name_starts_with_a, -> { where('name LIKE "a%"') }
+    end
 
     stub_model(:book) do
       include ActiveData::Model::Associations
@@ -59,6 +61,12 @@ describe ActiveData::Model::Associations::Reflections::ReferencesMany do
         before { book.authors << author }
         it { expect { book.authors.concat author }.not_to change { book.authors }.from([author]) }
       end
+    end
+
+    context 'scope missing method delegation' do
+      it { expect(book_with_author.authors.scope).to be_a ActiveRecord::Relation }
+      it { expect(book_with_author.authors.where(name: 'John')).to be_a ActiveRecord::Relation }
+      it { expect(book_with_author.authors.name_starts_with_a).to be_a ActiveRecord::Relation }
     end
   end
 

--- a/spec/lib/active_data/model/associations/reflections/references_many_spec.rb
+++ b/spec/lib/active_data/model/associations/reflections/references_many_spec.rb
@@ -1,0 +1,91 @@
+# encoding: UTF-8
+require 'spec_helper'
+
+describe ActiveData::Model::Associations::Reflections::ReferencesOne do
+  before do
+    stub_class(:author, ActiveRecord::Base)
+
+    stub_model(:book) do
+      include ActiveData::Model::Associations
+
+      attribute :title
+      references_many :authors
+    end
+  end
+  let(:book) { Book.new }
+
+  specify { expect(book.authors).to be_empty }
+
+  context ':class_name' do
+    before do
+      stub_model(:book) do
+        include ActiveData::Model::Associations
+
+        attribute :title
+        references_many :creators, class_name: 'Author'
+      end
+    end
+
+    let(:author) { Author.create!(name: 'Rick') }
+    let(:book) { Book.new }
+
+    specify { expect { book.creators << author }
+      .to change { book.creators }.from([]).to([author]) }
+    specify { expect { book.creators << author }
+      .to change { book.creator_ids }.from([]).to([author.id]) }
+  end
+
+  describe '#author' do
+    it { expect { book.authors.build(name: 'Rick') }.to raise_error ActiveData::OperationNotSupported }
+    it { expect { book.authors.create(name: 'Rick') }.to raise_error ActiveData::OperationNotSupported }
+    it { expect { book.authors.create!(name: 'Rick') }.to raise_error ActiveData::OperationNotSupported }
+
+    describe '#reload' do
+      before { book.authors << author }
+      it { expect { book.authors.reload }.to change { book.authors }.from([author]).to([]) }
+    end
+
+    describe '#concat' do
+      it { expect { book.authors.concat author }.to change { book.authors }.from([]).to([author]) }
+      context 'no duplication' do
+        before { book.authors << author}
+        it { expect { book.authors.concat author }.not_to change { book.authors }.from([author]) }
+      end
+    end
+  end
+
+  describe '#author=' do
+    let(:author) { Author.create! name: 'Author' }
+    specify { expect { book.authors = [author] }.to change { book.authors }.from([]).to([author]) }
+    specify { expect { book.authors = ['string'] }.to raise_error ActiveData::AssociationTypeMismatch }
+
+    context do
+      let(:other) { Author.create! name: 'Other' }
+      before { book.author = other }
+      specify { expect { book.author = author }.to change { book.author }.from(other).to(author) }
+      specify { expect { book.author = author }.to change { book.author_id }.from(other.id).to(author.id) }
+      specify { expect { book.author = nil }.to change { book.author }.from(other).to(nil) }
+      specify { expect { book.author = nil }.to change { book.author_id }.from(other.id).to(nil) }
+    end
+
+    context 'model not persisted' do
+      let(:author) { Author.new }
+      specify { expect { book.author = author }.to raise_error ActiveData::AssociationObjectNotPersisted }
+    end
+  end
+
+  describe '#author_id=' do
+    let(:author) { Author.create!(name: 'Author') }
+    specify { expect { book.author_id = author.id }.to change { book.author_id }.from(nil).to(author.id) }
+    specify { expect { book.author_id = author.id }.to change { book.author }.from(nil).to(author) }
+
+    context do
+      let(:other) { Author.create!(name: 'Other') }
+      before { book.author = other }
+      specify { expect { book.author_id = author.id }.to change { book.author_id }.from(other.id).to(author.id) }
+      specify { expect { book.author_id = author.id }.to change { book.author }.from(other).to(author) }
+      specify { expect { book.author_id = nil }.to change { book.author_id }.from(other.id).to(nil) }
+      specify { expect { book.author_id = nil }.to change { book.author }.from(other).to(nil) }
+    end
+  end
+end


### PR DESCRIPTION
Allow reference to many ActiveRecord objects via array of ids, defined as attribute:

```
references_many :class_name_in_plural
```