### PR TITLE
Add support for `update_only` option to nested attributes of collections

### DIFF
--- a/lib/active_data.rb
+++ b/lib/active_data.rb
@@ -96,11 +96,12 @@ module ActiveData
     end
   end
   typecaster('BigDecimal') do |value|
+    next unless value
     begin
       ::BigDecimal.new Float(value).to_s
     rescue
       nil
-    end if value
+    end
   end
   typecaster('Float') do |value|
     begin

--- a/lib/active_data/model/scopes.rb
+++ b/lib/active_data/model/scopes.rb
@@ -23,9 +23,11 @@ module ActiveData
           def initialize(source = nil, trust = false)
             source ||= self.class.superclass.new
 
-            source.each do |entity|
-              raise AssociationTypeMismatch.new(self.class._scope_model, entity.class) unless entity.is_a?(self.class._scope_model)
-            end unless trust && source.is_a?(self.class)
+            unless trust && source.is_a?(self.class)
+              source.each do |entity|
+                raise AssociationTypeMismatch.new(self.class._scope_model, entity.class) unless entity.is_a?(self.class._scope_model)
+              end
+            end
 
             super source
           end

--- a/spec/lib/active_data/model/nested_attributes.rb
+++ b/spec/lib/active_data/model/nested_attributes.rb
@@ -257,6 +257,30 @@ shared_examples 'nested attributes' do
             .to change { user.projects.map(&:title) }.to(['Project 2'])
         end
       end
+
+      context ':update_only' do
+        before { User.accepts_nested_attributes_for :projects, update_only: true }
+
+        specify do
+          expect do
+            user.projects_attributes = [
+              { slug: projects.first.slug.to_i, title: 'Project 3' },
+              { title: 'Project 4' }
+            ]
+          end
+            .to change { user.projects.map(&:title) }.to(['Project 3', 'Project 2'])
+        end
+
+        specify do
+          expect do
+            user.projects_attributes = [
+              { slug: projects.last.slug.to_i, title: 'Project 3' },
+              { slug: projects.first.slug.to_i.pred, title: 'Project 0' }
+            ]
+          end
+            .to change { user.projects.map(&:title) }.to(['Project 1', 'Project 3'])
+        end
+      end
     end
 
     context 'primary absence causes exception' do


### PR DESCRIPTION
Now, if a `accepts_nested_attributes_for` is defined for a collection association,
we can specify `update_only: true`. Then, new records will not be created in the
collection and will simply be ignored.

Before this PR, the `update_only` option was only supported by one-to-one associations.
For collection associations, it was simply ignored.