### PR TITLE
Fix reading boolean values from embedded models

### DIFF
--- a/lib/active_data.rb
+++ b/lib/active_data.rb
@@ -10,6 +10,7 @@ require 'active_model'
 require 'active_data/version'
 require 'active_data/errors'
 require 'active_data/extensions'
+require 'active_data/undefined_class'
 require 'active_data/config'
 require 'active_data/railtie' if defined? Rails
 require 'active_data/model'

--- a/lib/active_data/model/attributes.rb
+++ b/lib/active_data/model/attributes.rb
@@ -150,8 +150,9 @@ module ActiveData
       def attribute(name)
         reflection = self.class.reflect_on_attribute(name)
         return unless reflection
-        (@_attributes ||= {})[reflection.name] ||= reflection
-          .build_attribute(self, @initial_attributes.try(:[], reflection.name))
+        initial_value = @initial_attributes.to_h.fetch(reflection.name, ActiveData::UNDEFINED)
+        @_attributes ||= {}
+        @_attributes[reflection.name] ||= reflection.build_attribute(self, initial_value)
       end
 
       def write_attribute(name, value)

--- a/lib/active_data/model/attributes/reflections/base.rb
+++ b/lib/active_data/model/attributes/reflections/base.rb
@@ -12,8 +12,7 @@ module ActiveData
               new(name, options)
             end
 
-            def generate_methods(name, target)
-            end
+            def generate_methods(name, target) end
 
             def attribute_class
               @attribute_class ||= "ActiveData::Model::Attributes::#{name.demodulize}".constantize

--- a/lib/active_data/model/attributes/reflections/base.rb
+++ b/lib/active_data/model/attributes/reflections/base.rb
@@ -25,9 +25,9 @@ module ActiveData
             @options = options
           end
 
-          def build_attribute(owner, raw_value = nil)
+          def build_attribute(owner, raw_value = ActiveData::UNDEFINED)
             attribute = self.class.attribute_class.new(name, owner)
-            attribute.write_value(raw_value) if raw_value
+            attribute.write_value(raw_value) unless raw_value == ActiveData::UNDEFINED
             attribute
           end
 

--- a/lib/active_data/undefined_class.rb
+++ b/lib/active_data/undefined_class.rb
@@ -1,0 +1,9 @@
+require 'singleton'
+
+module ActiveData
+  class UndefinedClass
+    include Singleton
+  end
+
+  UNDEFINED = UndefinedClass.instance.freeze
+end

--- a/spec/lib/active_data/active_record/associations_spec.rb
+++ b/spec/lib/active_data/active_record/associations_spec.rb
@@ -203,6 +203,9 @@ describe ActiveData::ActiveRecord::Associations do
     specify { expect(User.reflect_on_association(:profile).klass).to be < Profile }
     specify { expect(User.new.profile).to be_nil }
     specify { expect(User.new.tap { |u| u.create_profile(first_name: 'Profile') }.profile).to be_a(User::Profile) }
-    specify { expect(User.new.tap { |u| u.create_profile(first_name: 'Profile') }.read_attribute(:profile)).to eq({ first_name: 'Profile', last_name: nil, admin: nil, age: nil }.to_json) }
+    specify do
+      expect(User.new.tap { |u| u.create_profile(first_name: 'Profile') }.read_attribute(:profile))
+        .to eq({ first_name: 'Profile', last_name: nil, admin: nil, age: nil }.to_json)
+    end
   end
 end

--- a/spec/lib/active_data/active_record/associations_spec.rb
+++ b/spec/lib/active_data/active_record/associations_spec.rb
@@ -22,6 +22,7 @@ describe ActiveData::ActiveRecord::Associations do
 
       attribute :first_name, String
       attribute :last_name, String
+      attribute :admin, Boolean
     end
 
     stub_class(:user, ActiveRecord::Base) do
@@ -86,6 +87,16 @@ describe ActiveData::ActiveRecord::Associations do
         user.save
         expect(user.reload.profile.first_name).to eq('google.com')
       end
+
+      context 'with profile already set' do
+        before { user.create_profile(admin: true) }
+
+        specify do
+          user.profile.admin = false
+          user.save
+          expect(user.reload.profile.admin).to eq(false)
+        end
+      end
     end
   end
 
@@ -140,7 +151,7 @@ describe ActiveData::ActiveRecord::Associations do
       specify do
         expect { user.profile = Profile.new(first_name: 'google.com') }
           .to change { user.read_attribute(:profile) }.from(nil)
-          .to({ first_name: 'google.com', last_name: nil }.to_json)
+          .to({ first_name: 'google.com', last_name: nil, admin: nil }.to_json)
       end
       specify do
         expect do
@@ -148,7 +159,7 @@ describe ActiveData::ActiveRecord::Associations do
           user.save
         end
           .to change { user.reload.read_attribute(:profile) }.from(nil)
-          .to({ first_name: 'google.com', last_name: nil }.to_json)
+          .to({ first_name: 'google.com', last_name: nil, admin: nil }.to_json)
       end
     end
   end
@@ -192,6 +203,6 @@ describe ActiveData::ActiveRecord::Associations do
     specify { expect(User.reflect_on_association(:profile).klass).to be < Profile }
     specify { expect(User.new.profile).to be_nil }
     specify { expect(User.new.tap { |u| u.create_profile(first_name: 'Profile') }.profile).to be_a(User::Profile) }
-    specify { expect(User.new.tap { |u| u.create_profile(first_name: 'Profile') }.read_attribute(:profile)).to eq({ first_name: 'Profile', last_name: nil, age: nil }.to_json) }
+    specify { expect(User.new.tap { |u| u.create_profile(first_name: 'Profile') }.read_attribute(:profile)).to eq({ first_name: 'Profile', last_name: nil, admin: nil, age: nil }.to_json) }
   end
 end

--- a/spec/lib/active_data/model/scopes_spec.rb
+++ b/spec/lib/active_data/model/scopes_spec.rb
@@ -19,8 +19,7 @@ describe ActiveData::Model::Scopes do
 
       private
 
-        def hidden_method
-        end
+        def hidden_method() end
       end
     end
   end


### PR DESCRIPTION
When boolean attribute of embedded model was false it is not being read and it always fails to default. Now we always set value stored in database, even if it was nil.