### PR TITLE
Add possibility to override type for `represents` attributes

### DIFF
--- a/lib/active_data/model/attributes/reflections/base.rb
+++ b/lib/active_data/model/attributes/reflections/base.rb
@@ -31,15 +31,21 @@ module ActiveData
           end
 
           def type
-            @type ||= case options[:type]
+            @type ||= type_class { raise "Type is not specified for `#{name}`" }
+          end
+
+          # block
+          def type_class
+            case options[:type]
             when Class, Module
               options[:type]
             when nil
-              raise "Type is not specified for `#{name}`"
+              yield
             else
               options[:type].to_s.camelize.constantize
             end
           end
+
 
           def typecaster
             @typecaster ||= ActiveData.typecaster(type.ancestors.grep(Class))

--- a/lib/active_data/model/attributes/reflections/represents.rb
+++ b/lib/active_data/model/attributes/reflections/represents.rb
@@ -20,7 +20,7 @@ module ActiveData
           end
 
           def type
-            Object
+            type_class { Object }
           end
 
           def reference


### PR DESCRIPTION
_Work in progress, specs coming soon_

Allow specifying type in represents definition
```
represents :id, Integer, of: :subject
```

