### PR TITLE
Fix nested attributes validation

### DIFF
--- a/lib/active_data/model/validations/nested.rb
+++ b/lib/active_data/model/validations/nested.rb
@@ -23,7 +23,9 @@ module ActiveData
         end
 
         def validate_each(record, attribute, value)
-          self.class.validate_nested(record, attribute, value, &:invalid?)
+          self.class.validate_nested(record, attribute, value) do |object|
+            object.invalid? && !object.marked_for_destruction?
+          end
         end
       end
 

--- a/spec/lib/active_data/model/validations/nested_spec.rb
+++ b/spec/lib/active_data/model/validations/nested_spec.rb
@@ -5,7 +5,9 @@ describe ActiveData::Model::Validations::NestedValidator do
     stub_model(:validated_assoc) do
       include ActiveData::Model
       include ActiveData::Model::Lifecycle
+      include ActiveData::Model::Primary
 
+      primary :id, Integer
       attribute :name, String
 
       validates_presence_of :name
@@ -87,6 +89,26 @@ describe ActiveData::Model::Validations::NestedValidator do
     specify do
       expect { instance.validate }.to change { instance.errors.messages }
         .to(:'validated_one.name' => ["can't be blank"])
+    end
+  end
+
+  context 'accepts nested attributes for one' do
+    before { Main.accepts_nested_attributes_for :validated_one, allow_destroy: true }
+    subject(:instance) { Main.instantiate name: 'hello', validated_one: { id: 1, name: 'name' } }
+
+    specify do
+      instance.validated_one_attributes = { id: 1, name: '', _destroy: true }
+      is_expected.to be_valid
+    end
+  end
+
+  context 'accepts nested attributes for many' do
+    before { Main.accepts_nested_attributes_for :validated_many, allow_destroy: true }
+    subject(:instance) { Main.instantiate name: 'hello', validated_many: [{ id: 1, name: 'name' }] }
+
+    specify do
+      instance.validated_many_attributes = [{ id: 1, name: '', _destroy: true }]
+      is_expected.to be_valid
     end
   end
 


### PR DESCRIPTION
When `allow_destroy` option is enabled for `accepts_nested_attributes_for` call, destroyed objects were validated, so parent object could be potentially invalid if attributes for a nested object was updated to invalid attributes and marked for destruction at the same time.