### PR TITLE
[WIP] Fix undefined method `marked_for_destruction?'

### DIFF
--- a/lib/active_data/model/validations/nested.rb
+++ b/lib/active_data/model/validations/nested.rb
@@ -24,7 +24,7 @@ module ActiveData
 
         def validate_each(record, attribute, value)
           self.class.validate_nested(record, attribute, value) do |object|
-            object.invalid? && !object.marked_for_destruction?
+            object.invalid? && !(object.respond_to?(:marked_for_destruction?) && object.marked_for_destruction?)
           end
         end
       end

--- a/spec/lib/active_data/model/validations/nested_spec.rb
+++ b/spec/lib/active_data/model/validations/nested_spec.rb
@@ -112,6 +112,41 @@ describe ActiveData::Model::Validations::NestedValidator do
     end
   end
 
+  context 'represented field is invalid and represented object does not include AutosaveAssociation' do
+    before do
+      stub_class(:validated_represented) do
+        include ActiveData::Model::Validations
+        include ActiveData::Model::Attributes
+        include ActiveData::Model::Primary
+
+        primary :id
+        attribute :title, String
+        validates_presence_of :title
+      end
+
+      Main.class_eval do
+        include ActiveData::Model::Associations
+        attribute :represented, Object
+        validates :represented, nested: true
+      end
+    end
+
+    subject(:instance) { Main.instantiate name: 'hello', represented: represented, validated_one: { name: 'name' } }
+
+    context do
+      let(:represented) { ValidatedRepresented.new(title: 'Mr.') }
+      it { is_expected.to be_valid }
+    end
+
+    context do
+      let(:represented) { ValidatedRepresented.new }
+      it do
+        expect { subject.valid? }.not_to raise_error(NoMethodError)
+        expect(subject).not_to be_valid
+      end
+    end
+  end
+
   context do
     subject(:instance) { Main.instantiate name: 'hello', validated_many: [{}], validated_one: { name: 'name' } }
     it { is_expected.not_to be_valid }


### PR DESCRIPTION
This error appeared after applying fix: https://github.com/pyromaniac/active_data/pull/37

It is possible to have represented attributes of an object which does not respond to `marked_for_destruction?`. One of the fix would be to `include ActiveRecord::AutosaveAssociation` but probably better is to fix ActveData. 

~~To make this spec more complete I wanted to add a case when represented object is not valid, but it's not behaving as I thought it would - the main object is still valid, even though `represented` is invalid. I'm open for suggestions.~~ all fixed