### PR TITLE
Make active_data support ActionController::Parameters

### DIFF
--- a/lib/active_data/model/attributes.rb
+++ b/lib/active_data/model/attributes.rb
@@ -183,6 +183,7 @@ module ActiveData
       alias_method :update_attributes, :update
 
       def assign_attributes(attrs)
+        attrs = attrs.to_unsafe_hash if attrs.respond_to?(:to_unsafe_hash)
         if self.class.represented_attributes.present? ||
             (self.class.is_a?(ActiveData::Model::Associations::NestedAttributes) &&
             self.class.nested_attributes_options.present?)

--- a/spec/lib/active_data/model/attributes_spec.rb
+++ b/spec/lib/active_data/model/attributes_spec.rb
@@ -129,6 +129,11 @@ describe ActiveData::Model::Attributes do
 
     specify { expect { subject.assign_attributes(attributes) }.to change { subject.id }.to(42) }
     specify { expect { subject.assign_attributes(attributes) }.to change { subject.full_name }.to('Name') }
+
+    context 'ActionController::Parameters' do
+      let(:params) { instance_double('ActionController::Parameters', to_unsafe_hash: attributes) }
+      specify { subject.assign_attributes(params) }
+    end
   end
 
   describe '#inspect' do


### PR DESCRIPTION
Rails 5 introduce ActionController::Parameters, which are not tied to Hash class anymore. As active_data have its own key permission system we can easily convert params to an unsafe hash.
