### PR TITLE
Make attributes defaults consider initial value presence [WiP]

### DIFF
--- a/lib/active_data/model/associations.rb
+++ b/lib/active_data/model/associations.rb
@@ -26,6 +26,8 @@ module ActiveData
     module Associations
       extend ActiveSupport::Concern
 
+      CHECKER = ->(ref, object) { object.attribute_initially_provided?(ref.name) }
+
       included do
         include NestedAttributes
 
@@ -42,7 +44,10 @@ module ActiveData
           references_many: Reflections::ReferencesMany
         }.each do |(name, reflection_class)|
           define_singleton_method name do |*args, &block|
-            reflection = reflection_class.build self, generated_associations_methods, *args, &block
+            options = args.extract_options!
+            reflection = reflection_class.build(self, generated_associations_methods, *args,
+              options.reverse_merge(check: CHECKER),
+              &block)
             self._associations = _associations.merge(reflection.name => reflection)
             reflection
           end

--- a/lib/active_data/model/associations/base.rb
+++ b/lib/active_data/model/associations/base.rb
@@ -8,7 +8,7 @@ module ActiveData
         def initialize(owner, reflection)
           @owner = owner
           @reflection = reflection
-          @evar_loaded = owner.persisted?
+          @evar_loaded = owner.persisted? && source_present?
           reset
         end
 
@@ -73,6 +73,10 @@ module ActiveData
         end
 
       private
+
+        def source_present?
+          reflection.source_present? owner
+        end
 
         def read_source
           reflection.read_source owner

--- a/lib/active_data/model/associations/references_any.rb
+++ b/lib/active_data/model/associations/references_any.rb
@@ -8,6 +8,10 @@ module ActiveData
 
       private
 
+        def source_present?
+          owner.attribute_initially_provided?(reflection.reference_key)
+        end
+
         def read_source
           attribute.read_before_type_cast
         end

--- a/lib/active_data/model/associations/reflections/base.rb
+++ b/lib/active_data/model/associations/reflections/base.rb
@@ -59,6 +59,11 @@ module ActiveData
             self.class.association_class.new object, self
           end
 
+          def source_present?(object)
+            return true unless options[:check]
+            options[:check].call(self, object)
+          end
+
           def read_source(object)
             (options[:read] || READ).call(self, object)
           end

--- a/lib/active_data/model/attributes.rb
+++ b/lib/active_data/model/attributes.rb
@@ -120,6 +120,10 @@ module ActiveData
       end
       alias_method :eql?, :==
 
+      def attribute_initially_provided?(name)
+        @initial_attributes.to_h.key?(name.to_s)
+      end
+
       def attribute(name)
         reflection = self.class.reflect_on_attribute(name)
         return unless reflection


### PR DESCRIPTION
An attempt to make defaults consider initial value presence

Case description:

When an AR persisted attribute (e.g. json field) embeds another value, defaults do not apply because the whole record is considered persisted. However, this goes against natural expectation or using the default when json key is not present in the persisted record.

This is a pair programming attempt to fix this with @pyromaniac. The code is WiP, since a spec that is expected to go red didn't do so, indicating the need to rethink the behavior.