### PR TITLE
Fix rubocop offenses

### DIFF
--- a/active_data.gemspec
+++ b/active_data.gemspec
@@ -14,18 +14,18 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = ActiveData::VERSION
 
-  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'activerecord', '>= 4.0'
   gem.add_development_dependency 'appraisal'
+  gem.add_development_dependency 'database_cleaner'
+  gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rspec-its'
+  gem.add_development_dependency 'rubocop'
   gem.add_development_dependency 'rubysl', '~> 2.0' if RUBY_ENGINE == 'rbx'
   gem.add_development_dependency 'sqlite3'
-  gem.add_development_dependency 'database_cleaner'
-  gem.add_development_dependency 'activerecord', '>= 4.0'
   gem.add_development_dependency 'uuidtools'
-  gem.add_development_dependency 'rubocop'
 
-  gem.add_runtime_dependency 'activesupport', '>= 4.0'
   gem.add_runtime_dependency 'activemodel', '>= 4.0'
+  gem.add_runtime_dependency 'activesupport', '>= 4.0'
   gem.add_runtime_dependency 'tzinfo'
 end

--- a/lib/active_data/model/associations/references_any.rb
+++ b/lib/active_data/model/associations/references_any.rb
@@ -27,6 +27,14 @@ module ActiveData
         def persist_object(object, **options)
           reflection.persistence_adapter.persist(object, **options)
         end
+
+        def matches_type?(object)
+          object.is_a?(reflection.persistence_adapter.data_type)
+        end
+
+        def raise_type_mismatch(object)
+          raise AssociationTypeMismatch.new(reflection.persistence_adapter.data_type, object.class)
+        end
       end
     end
   end

--- a/lib/active_data/model/associations/references_many.rb
+++ b/lib/active_data/model/associations/references_many.rb
@@ -96,9 +96,8 @@ module ActiveData
           attribute.pollute do
             objects.each do |object|
               next if target.include?(object)
-              unless object.is_a?(reflection.persistence_adapter.data_type)
-                raise AssociationTypeMismatch.new(reflection.persistence_adapter.data_type, object.class)
-              end
+              raise_type_mismatch(object) unless matches_type?(object)
+
               target.push(object)
               write_source(identify)
             end

--- a/lib/active_data/model/associations/references_one.rb
+++ b/lib/active_data/model/associations/references_one.rb
@@ -63,9 +63,7 @@ module ActiveData
         end
 
         def replace(object)
-          unless object.nil? || object.is_a?(reflection.persistence_adapter.data_type)
-            raise AssociationTypeMismatch.new(reflection.persistence_adapter.data_type, object.class)
-          end
+          raise_type_mismatch(object) unless object.nil? || matches_type?(object)
 
           transaction do
             attribute.pollute do

--- a/lib/active_data/model/associations/reflections/embeds_many.rb
+++ b/lib/active_data/model/associations/reflections/embeds_many.rb
@@ -4,9 +4,7 @@ module ActiveData
       module Reflections
         class EmbedsMany < EmbedsAny
           def self.build(target, generated_methods, name, options = {}, &block)
-            if target < ActiveData::Model::Attributes
-              target.add_attribute(ActiveData::Model::Attributes::Reflections::Base, name)
-            end
+            target.add_attribute(ActiveData::Model::Attributes::Reflections::Base, name) if target < ActiveData::Model::Attributes
             options[:validate] = true unless options.key?(:validate)
             super
           end

--- a/lib/active_data/model/associations/reflections/embeds_one.rb
+++ b/lib/active_data/model/associations/reflections/embeds_one.rb
@@ -6,9 +6,7 @@ module ActiveData
           include Singular
 
           def self.build(target, generated_methods, name, options = {}, &block)
-            if target < ActiveData::Model::Attributes
-              target.add_attribute(ActiveData::Model::Attributes::Reflections::Base, name)
-            end
+            target.add_attribute(ActiveData::Model::Attributes::Reflections::Base, name) if target < ActiveData::Model::Attributes
             options[:validate] = true unless options.key?(:validate)
             super
           end

--- a/lib/active_data/model/attributes.rb
+++ b/lib/active_data/model/attributes.rb
@@ -32,9 +32,8 @@ module ActiveData
         def add_attribute(reflection_class, *args, &block)
           reflection = reflection_class.build(self, generated_attributes_methods, *args, &block)
           self._attributes = _attributes.merge(reflection.name => reflection)
-          if dirty? && reflection_class != ActiveData::Model::Attributes::Reflections::Base
-            define_dirty reflection.name, generated_attributes_methods
-          end
+          should_define_dirty = (dirty? && reflection_class != ActiveData::Model::Attributes::Reflections::Base)
+          define_dirty(reflection.name, generated_attributes_methods) if should_define_dirty
           reflection
         end
 

--- a/lib/active_data/model/attributes/reference_one.rb
+++ b/lib/active_data/model/attributes/reference_one.rb
@@ -6,9 +6,9 @@ module ActiveData
           pollute do
             previous = type_casted_value
             result = write_value value
-            if (!value.nil? && type_casted_value.nil?) || type_casted_value != previous
-              association.reset
-            end
+            changed = (!value.nil? && type_casted_value.nil?) || type_casted_value != previous
+
+            association.reset if changed
             result
           end
         end

--- a/lib/active_data/model/attributes/reflections/represents.rb
+++ b/lib/active_data/model/attributes/reflections/represents.rb
@@ -9,9 +9,8 @@ module ActiveData
             reference = target.reflect_on_association(options[:of]) if target.respond_to?(:reflect_on_association)
             reference ||= target.reflect_on_attribute(options[:of]) if target.respond_to?(:reflect_on_attribute)
             options[:of] = reference.name if reference
-            if target.respond_to?(:validates_nested) && !target.validates_nested?(options[:of])
-              target.validates_nested options[:of]
-            end
+            validates_nested = target.respond_to?(:validates_nested) && !target.validates_nested?(options[:of])
+            target.validates_nested(options[:of]) if validates_nested
 
             super(target, generated_methods, name, *args, options, &block)
           end

--- a/spec/lib/active_data/model/callbacks_spec.rb
+++ b/spec/lib/active_data/model/callbacks_spec.rb
@@ -176,14 +176,12 @@ describe ActiveData::Model::Callbacks do
         create
         after_around_create after_create
         after_around_save after_save
-
         before_validation after_validation
         before_save before_around_save
         before_update before_around_update
         update
         after_around_update after_update
         after_around_save after_save
-
         before_destroy before_around_destroy
         destroy
         after_around_destroy after_destroy

--- a/spec/lib/active_data/model/typecasting_spec.rb
+++ b/spec/lib/active_data/model/typecasting_spec.rb
@@ -99,6 +99,7 @@ describe ActiveData::Model::Attributes do
     specify { expect(model.new(column: 10).column).to be_nil }
   end
 
+  # rubocop:disable Style/DateTime
   context 'date' do
     let(:model) { stub_model { attribute :column, Date } }
     let(:date) { Date.new(2013, 6, 13) }
@@ -148,6 +149,7 @@ describe ActiveData::Model::Attributes do
       specify { expect(model.new(column: Time.new(2013, 6, 13, 23, 13)).column).to eq(Time.new(2013, 6, 13, 23, 13)) }
     end
   end
+  # rubocop:enable Style/DateTime
 
   context 'time_zone' do
     let(:model) { stub_model { attribute :column, ActiveSupport::TimeZone } }

--- a/spec/shared/nested_attribute_examples.rb
+++ b/spec/shared/nested_attribute_examples.rb
@@ -115,7 +115,7 @@ shared_examples 'nested attributes' do
 
     context 'generated method overwrites' do
       before do
-        User.class_eval <<-RUBY
+        User.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def profile_attributes=(args)
             args.reverse_merge!(first_name: 'Default Profile Name')
             super
@@ -315,7 +315,7 @@ shared_examples 'nested attributes' do
 
     context 'generated method overwrites' do
       before do
-        User.class_eval <<-RUBY
+        User.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def projects_attributes=(args)
             args << {title: 'Default Project'}
             super


### PR DESCRIPTION
Most were about using if/unless modifier when if body had a single line. Also disabled check for Style/DateTime in the typecasting specs, as they make sense there.