### PR TITLE
Remove ruby version constraint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.rvmrc
+.version-conf
+.ruby-version
+.ruby-gemset

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm use --create 2.4@active_data


### PR DESCRIPTION
Having an `.rvmrc` file infers that the contributor has RVM isntalled,
while this is not always the case, due to an number of alternatives.

Not having standard `.ruby-version`, `.ruby-gemset`, and `.version.conf`
in `.gitignore` is also putting a roadblock for those using alternative
ruby version managers and modern approach to version management
configuration.

Those files should remain in local repositories and not be tracked.