### PR TITLE
Update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
+dist: bionic
 sudo: false
+language: ruby
 
 rvm:
-  - 2.2.10
-  - 2.3.7
-  - 2.4.4
-  - rbx
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2
 
 gemfile:
   - gemfiles/rails.4.0.gemfile
@@ -15,14 +17,24 @@ gemfile:
   - gemfiles/rails.5.2.gemfile
 
 matrix:
-  allow_failures:
-    - rvm: rbx
   exclude:
-    - rvm: 2.4.4
+    - rvm: 2.4.6
       gemfile: gemfiles/rails.4.0.gemfile
-    - rvm: 2.4.4
+    - rvm: 2.4.6
       gemfile: gemfiles/rails.4.1.gemfile
-    - rvm: 2.4.4
+    - rvm: 2.4.6
+      gemfile: gemfiles/rails.4.2.gemfile
+    - rvm: 2.5.5
+      gemfile: gemfiles/rails.4.0.gemfile
+    - rvm: 2.5.5
+      gemfile: gemfiles/rails.4.1.gemfile
+    - rvm: 2.5.5
+      gemfile: gemfiles/rails.4.2.gemfile
+    - rvm: 2.6.2
+      gemfile: gemfiles/rails.4.0.gemfile
+    - rvm: 2.6.2
+      gemfile: gemfiles/rails.4.1.gemfile
+    - rvm: 2.6.2
       gemfile: gemfiles/rails.4.2.gemfile
 
 before_install:

--- a/active_data.gemspec
+++ b/active_data.gemspec
@@ -21,8 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~> 3.7.0'
   gem.add_development_dependency 'rspec-its'
   gem.add_development_dependency 'rubocop', '0.52.1'
-  gem.add_development_dependency 'rubysl', '~> 2.0' if RUBY_ENGINE == 'rbx'
-  gem.add_development_dependency 'sqlite3'
+  gem.add_development_dependency 'sqlite3', '~> 1.3.13'
   gem.add_development_dependency 'uuidtools'
 
   gem.add_runtime_dependency 'activemodel', '>= 4.0'


### PR DESCRIPTION
Drop ruby-2.2, update 2.[34] & add 2.[56] to travis.

ruby-2.2 is not supported by rubygems-update-3.0.6.gem,
so `bundle update --system` fails. Just drop it, it's EOLed.

Drop rbx since currently installation fails with
`Requested binary installation but no rubies are available to download, consider skipping --binary flag.`
and rbx-[2-4] fails to build some c-ext

sqlite-1.4 leads to
`can't activate sqlite3 (~> 1.3.6), already activated sqlite3-1.4.1. Make sure all dependencies are added to Gemfile.`
on travis, so use sqlite-1.3