### PR TITLE
Fix deprecation warning in ruby-2.6

### DIFF
--- a/lib/active_data.rb
+++ b/lib/active_data.rb
@@ -100,7 +100,7 @@ module ActiveData
   typecaster('BigDecimal') do |value|
     next unless value
     begin
-      ::BigDecimal.new Float(value).to_s
+      BigDecimal(Float(value).to_s)
     rescue ArgumentError, TypeError
       nil
     end


### PR DESCRIPTION
`warning: BigDecimal.new is deprecated; use BigDecimal() method instead.`