### PR TITLE
Fix typo in nested attributes spec

### DIFF
--- a/spec/lib/active_data/model/associations/nested_attributes_spec.rb
+++ b/spec/lib/active_data/model/associations/nested_attributes_spec.rb
@@ -22,7 +22,7 @@ describe ActiveData::Model::Associations::NestedAttributes do
     include_examples 'nested attributes'
   end
 
-  xcontext 'references_one' do
+  context 'references_one' do
     before do
       stub_class(:author, ActiveRecord::Base)
       stub_class(:user, ActiveRecord::Base)


### PR DESCRIPTION
Hi @pyromaniac, I found a tiny issue in the "nested_attributes_spec" line 25, it seems to have a small typo there.