### PR TITLE
Copy whole errors (both type and message) for represented attribtues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0
+        ruby-version: '3.0'
         bundler-cache: true
     - run: bundle exec rubocop

--- a/lib/active_data/model/representation.rb
+++ b/lib/active_data/model/representation.rb
@@ -74,9 +74,11 @@ module ActiveData
 
       if ActiveModel.version >= Gem::Version.new('6.1.0')
         def move_errors(from, to)
-          errors[from].each do |error_message|
-            errors.add(to, error_message)
-            errors.delete(from)
+          errors.each do |error|
+            next unless error.attribute == from
+
+            errors.add(to, error.type, message: error.message)
+            errors.delete(error.attribute, error.type)
           end
         end
       else # up to 6.0.x

--- a/lib/active_data/version.rb
+++ b/lib/active_data/version.rb
@@ -1,3 +1,3 @@
 module ActiveData
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.2.1'.freeze
 end

--- a/spec/lib/active_data/model/representation_spec.rb
+++ b/spec/lib/active_data/model/representation_spec.rb
@@ -128,5 +128,10 @@ describe ActiveData::Model::Representation do
       expect { post.validate }.to change { post.errors.messages }
         .to(hash_including('author.user.email': ['is invalid'], name: ["can't be blank"]))
     end
+
+    specify do
+      expect { post.validate }.to change { post.errors.details }
+        .to(hash_including('author.user.email': [{error: 'is invalid'}], name: [{error: :blank}]))
+    end
   end
 end

--- a/spec/lib/active_data/model/representation_spec.rb
+++ b/spec/lib/active_data/model/representation_spec.rb
@@ -129,9 +129,11 @@ describe ActiveData::Model::Representation do
         .to(hash_including('author.user.email': ['is invalid'], name: ["can't be blank"]))
     end
 
-    specify do
-      expect { post.validate }.to change { post.errors.details }
-        .to(hash_including('author.user.email': [{error: 'is invalid'}], name: [{error: :blank}]))
+    if ActiveModel.version >= Gem::Version.new('6.1.0')
+      specify do
+        expect { post.validate }.to change { post.errors.details }
+          .to(hash_including('author.user.email': [{error: 'is invalid'}], name: [{error: :blank}]))
+      end
     end
   end
 end


### PR DESCRIPTION
### Description

For validation errors added by built-in validations:
```ruby
validates :name, presence: true
```
or by explicitly setting the type of error:
```ruby
errors.add(:email, :weired, message: 'is weired')
```
errors' details on represented attributes are inconsistent with error type, set by such validations:

```ruby
class Author < ActiveRecord::Base
  validates :name, presence: true
end

class Post
  include ActiveData::Model
  include ActiveData::Model::Associations
  include ActiveData::Model::Representation

  references_one :author
  represents :name, of: :author
end

author = Author.new.tap(&:validate)
post   = Post.new(author: author).tap(&:validate)


> author.errors.details 
=> {:name=>[{:error=>:blank}]} # correct

> post.errors.details
=> {:name=>[{:error=>"can't be blank"}]} # incorrect, we see a string error message, instead of :blank

```

This PR fixes this behavior:
```ruby
> post.errors.details
=> {:name=>[{:error=>:blank}]}
```